### PR TITLE
Unpin versions to fix mybinder build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.11
-pandas==0.19
-matplotlib==2.0
-scipy==0.17.0
+numpy
+pandas
+matplotlib
+scipy


### PR DESCRIPTION
With the versions unpinned this builds successfully on mybinder.org again.

The hunch is that we recently switched the base image used (long story why) and for the older versions of numpy and co there are no wheels for python3.6. So as a result numpy had to be compiled from scratch for which we apparently are missing a header.